### PR TITLE
Adição do Middleware CORS no projeto

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,21 @@
 import {AppDataSource} from './src/config/data-source.js';
 import express from 'express';
 import dotenv from 'dotenv';
+import cors from 'cors';
+
+// Configuração do CORS
+const allowedOrigins = ['http://localhost:3000'];
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+};
+app.use(cors(corsOptions));
+
 //Routes
 import DashboardInternaRoutes from './src/routes/DashBoardInternaRoutes.js';
 import DashboardExternaRoutes from './src/routes/DashBoardExternaRoutes.js';

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const corsOptions = {
     }
   },
 };
-app.use(cors(corsOptions));
+
 
 //Routes
 import DashboardInternaRoutes from './src/routes/DashBoardInternaRoutes.js';
@@ -44,6 +44,7 @@ app.get('/', (req, res) => {
 // Middleware para tratamento de erros
 app.use(errorHandler);
 
+app.use(cors(corsOptions));
 const PORT = process.env.PORT;
 
 // Estabelecer Conexão com o banco de dados

--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ dotenv.config();
 const app = express();
 app.use(express.urlencoded({extended: false}));
 app.use(express.json());
+// O middleware do cors deve ser aplicado antes de definir as rotas para o funcionamento correto
+app.use(cors(corsOptions));
 // Importando Rotas
 app.use('/', DashboardInternaRoutes);
 app.use('/', DashboardExternaRoutes);
@@ -44,7 +46,7 @@ app.get('/', (req, res) => {
 // Middleware para tratamento de erros
 app.use(errorHandler);
 
-app.use(cors(corsOptions));
+
 const PORT = process.env.PORT;
 
 // Estabelecer Conexão com o banco de dados

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dash-be-develop",
       "version": "0.0.1",
       "dependencies": {
+        "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "pg": "^8.4.0",
@@ -871,6 +872,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1973,6 +1987,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Backend para dashboards relacionados as votacoes",
   "type": "module",
   "dependencies": {
+    "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "pg": "^8.4.0",


### PR DESCRIPTION
Configurei o CORS para funcionar no projeto

Criei os endereços permitidos em forma de lista para facilitar a adição do endereço de produção futuramente. 
Permiti o acesso de requisições do `localhost:3000` para o front-end e também requisições sem origem (para testes com Postman ou Insomnia)