### PR TITLE
Criacao da rota v1/dashboard/externa

### DIFF
--- a/src/controllers/DashboardExternaController.js
+++ b/src/controllers/DashboardExternaController.js
@@ -1,3 +1,15 @@
-class DashBoardExternaController {}
+import DashboardExternaService from '../services/DashboardExternaService.js';
+class DashBoardExternaController {
+  async findDashboardExternaAtivoGeral(req, res, next) {
+    try {
+      const response =
+        await DashboardExternaService.findEventosExternosGeralAtivo();
+      return res.status(200).json(response);
+    } catch (error) {
+      console.error('Erro ao executar consulta dos Eventos Externos Geral!');
+      next(error); // Passa o erro para o middleware de tratamento de erros
+    }
+  }
+}
 
 export default new DashBoardExternaController();

--- a/src/routes/DashBoardExternaRoutes.js
+++ b/src/routes/DashBoardExternaRoutes.js
@@ -1,4 +1,9 @@
+import DashboardExternaController from '../controllers/DashboardExternaController.js';
 import express from 'express';
 const routerExterna = express.Router();
+routerExterna.get(
+  '/v1/dashboard/externo/ativo',
+  DashboardExternaController.findDashboardExternaAtivoGeral,
+);
 
 export default routerExterna;

--- a/src/services/DashboardExternaService.js
+++ b/src/services/DashboardExternaService.js
@@ -1,0 +1,93 @@
+import {AppDataSource} from '../config/data-source.js';
+import NotFoundError from '../errors/NotFoundError.js';
+class DashBoardInterna {
+  async findEventosExternosGeralAtivo() {
+    const query = `
+        SELECT 
+            e.id_evento,
+            e.tipo_evento,
+            e.nome_evento,
+            e.descricao_evento,
+            e.status_evento,
+            to_char(e.data_inicio, 'DD/MM/YYYY') AS data_inicio,
+            to_char(e.data_fim, 'DD/MM/YYYY') AS data_fim,
+
+            -- Total de votos válidos (externos)
+            (
+                SELECT COUNT(*) 
+                FROM "VotosExternos" ve 
+                WHERE ve.fk_id_evento = e.id_evento
+            ) AS total_votos_evento,
+
+            -- Total de projetos no evento
+            (
+                SELECT COUNT(DISTINCT pe.fk_id_projeto)
+                FROM "ProjetosEventos" pe 
+                WHERE pe.fk_id_evento = e.id_evento
+            ) AS total_projetos_evento,
+
+            -- Total de visitantes únicos que votaram
+            (
+                SELECT COUNT(DISTINCT ve.fk_id_visitante)
+                FROM "VotosExternos" ve
+                WHERE ve.fk_id_evento = e.id_evento
+            ) AS total_visitantes_votantes,
+
+            -- Votos por dia (json)
+            (
+                SELECT json_agg(vpd)
+                FROM (
+                    SELECT 
+                        to_char(ve.data_criacao::date, 'DD/MM/YYYY') AS data,
+                        COUNT(*) AS qtd_votos
+                    FROM "VotosExternos" ve
+                    WHERE ve.fk_id_evento = e.id_evento
+                    GROUP BY ve.data_criacao::date
+                    ORDER BY ve.data_criacao::date
+                ) AS vpd
+            ) AS votos_por_dia,
+
+            -- Projetos participantes com informações detalhadas
+            (
+                SELECT json_agg(projetos)
+                FROM (
+                    SELECT 
+                        p.id_projeto,
+                        p.titulo AS nome_projeto,
+
+                        -- Subquery para pegar os integrantes sem repetição
+                        (
+                            SELECT STRING_AGG(DISTINCT u.nome, ', ')
+                            FROM "IntegrantesEquipe" ie
+                            JOIN "Alunos" a ON a.id_aluno = ie.aluno_id
+                            JOIN "Usuarios" u ON u.id = a.fk_id_usuario
+                            WHERE ie.projeto_id = p.id_projeto
+                        ) AS integrantes,
+
+                        -- Votos recebidos
+                        (
+                            SELECT COUNT(*) 
+                            FROM "VotosExternos" ve
+                            WHERE ve.fk_id_projeto = p.id_projeto AND ve.fk_id_evento = e.id_evento
+                        ) AS votos_recebidos
+
+                    FROM "ProjetosEventos" pe
+                    JOIN "Projetos" p ON p.id_projeto = pe.fk_id_projeto
+                    WHERE pe.fk_id_evento = e.id_evento
+                ) AS projetos
+            ) AS projetos_participantes
+
+        FROM "Eventos" e
+        WHERE e.tipo_evento = 'Externo' AND e.status_evento = 'Ativo'
+        ORDER BY e.data_inicio DESC;
+    `;
+    const result = await AppDataSource.query(query);
+    if (!result || result.length === 0) {
+      throw new NotFoundError('Nenhum evento externo ativo encontrado.');
+    }
+
+    console.log('Dados do Evento Externo Geral obtidos com sucesso!');
+    return result;
+  }
+}
+export default new DashBoardInterna();


### PR DESCRIPTION
# PR para a criação da rota para envio dos dados dos eventos externos

## Obs
Usei como base o padrão estabelecido na rota #42 

## Dashboard externa de eventos ativos

- `v1/dashboard/externa/ativo`
- rota: `http://localhost:5000/v1/dashboard/externo/ativo`
- Resposta
    
    ```bash
    {
    		"id_evento": 15,
    		"tipo_evento": "Externo",
    		"nome_evento": "Feira de Profissões",
    		"descricao_evento": "Evento aberto ao público",
    		"status_evento": "Ativo",
    		"data_inicio": "05/05/2025",
    		"data_fim": "06/05/2025",
    		"total_votos_evento": "4",
    		"total_projetos_evento": "2",
    		"total_visitantes_votantes": "4",
    		"votos_por_dia": [
    			{
    				"data": "05/05/2025",
    				"qtd_votos": 2
    			},
    			{
    				"data": "06/05/2025",
    				"qtd_votos": 2
    			}
    		],
    		"projetos_participantes": [
    			{
    				"id_projeto": 1,
    				"nome_projeto": "Desenvolvimento de Plataforma Educacional Online",
    				"integrantes": "Usuario 1, Usuario 2, Usuario 3",
    				"votos_recebidos": 3
    			},
    			{
    				"id_projeto": 2,
    				"nome_projeto": "Sistema Inteligente de Monitoramento Ambiental",
    				"integrantes": "Usuario 4, Usuario 5",
    				"votos_recebidos": 1
    			}
    		]
    	}
    ```